### PR TITLE
Support IE11

### DIFF
--- a/packages/cli/src/dev.js
+++ b/packages/cli/src/dev.js
@@ -26,7 +26,7 @@ export default {
     },
     host: {
       description: 'webserver address',
-      default: 'localhost',
+      default: '0.0.0.0',
     },
     port: {
       description: 'webserver port',

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,18 +25,19 @@
   "dependencies": {
     "babel-cli": "6.26.0",
     "babel-core": "6.26.0",
-    "babel-plugin-syntax-dynamic-import": "^6.18.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-syntax-dynamic-import": "6.18.0",
+    "babel-plugin-transform-object-rest-spread": "6.26.0",
+    "babel-polyfill": "6.26.0",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "copy-webpack-plugin": "4.3.1",
     "html-webpack-plugin": "2.30.1",
     "raw-loader": "0.5.1",
-    "resolve-url-loader": "^2.2.1",
+    "resolve-url-loader": "2.2.1",
     "webpack": "3.10.0",
     "webpack-blocks": "1.0.0-rc.2",
     "webpack-dev-server": "2.11.1",
-    "webpack-sources": "^1.1.0"
+    "webpack-sources": "1.1.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/packages/core/src/defaultConfig.js
+++ b/packages/core/src/defaultConfig.js
@@ -5,4 +5,6 @@ export default {
   contentBase: 'public',
   template: 'index.html',
   title: 'Stylegator',
+  host: '0.0.0.0',
+  port: 8080,
 }

--- a/packages/core/src/dev.js
+++ b/packages/core/src/dev.js
@@ -16,7 +16,12 @@ export default argv => {
   WebpackDevServer.addDevServerEntrypoints(compilerConfig, serverConfig)
   const compiler = webpack(compilerConfig)
   const server = new WebpackDevServer(compiler, serverConfig)
-  server.listen(8080, '127.0.0.1', () => {
-    console.log('Starting server on http://localhost:8080')
+
+  server.listen(port, host, () => {
+    console.log(
+      `Starting server on http://${
+        host === '0.0.0.0' ? 'localhost' : host
+      }:${port}`
+    )
   })
 }

--- a/packages/core/src/webpack.config.js
+++ b/packages/core/src/webpack.config.js
@@ -56,7 +56,7 @@ export default userConfig => {
   }
 
   return createConfig([
-    entryPoint(path.resolve(process.cwd(), srcDir, entry)),
+    entryPoint(['babel-polyfill', path.resolve(process.cwd(), srcDir, entry)]),
     match(['*.md'], [raw()]),
     match(['*.css'], [resolveUrl()]),
     match(['*.gif', '*.jpg', '*.jpeg', '*.png', '*.svg'], [file()]),

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -24,8 +24,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "prop-types-docs": "0.1.1",
-    "stylegator": "^0.8.0"
+    "prop-types-docs": "0.1.2",
+    "stylegator": "0.8.0"
   },
   "devDependencies": {
     "husky": "0.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5782,9 +5782,9 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types-docs@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/prop-types-docs/-/prop-types-docs-0.1.1.tgz#69f8843215a275389d1ada271b95f2e6d26697f3"
+prop-types-docs@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/prop-types-docs/-/prop-types-docs-0.1.2.tgz#3aede6a50ff89f5b974ad2267db7ac087fd84736"
 
 prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"


### PR DESCRIPTION
- Defaults host to `0.0.0.0` to support access thru VM
- Adds `babel-polyfill` to webpack entry