### PR TITLE
Prerelease (next) 0.10.3-rc.6

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.10.2",
+  "version": "0.10.3-rc.6",
   "npmClient": "yarn",
   "parallel": true,
   "message": "[ci skip] publish %s",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/app",
-  "version": "0.10.2",
+  "version": "0.10.3-rc.6",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/cli",
-  "version": "0.10.2",
+  "version": "0.10.3-rc.6",
   "description": "Stylegator CLI tool",
   "main": "lib/index.js",
   "repository": {
@@ -26,7 +26,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/core": "^0.10.2"
+    "@stylegator/core": "^0.10.3-rc.6"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/core",
-  "version": "0.10.2",
+  "version": "0.10.3-rc.6",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@stylegator/docs",
-  "version": "0.10.2",
+  "version": "0.10.3-rc.6",
   "description": "Stylegator main package",
   "main": "lib/index.js",
   "repository": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "prop-types-docs": "0.1.3",
-    "stylegator": "^0.10.2"
+    "stylegator": "^0.10.3-rc.6"
   },
   "devDependencies": {
     "husky": "0.14.3",

--- a/packages/stylegator/package.json
+++ b/packages/stylegator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylegator",
-  "version": "0.10.2",
+  "version": "0.10.3-rc.6",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {
@@ -26,9 +26,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/app": "^0.10.2",
-    "@stylegator/cli": "^0.10.2",
-    "@stylegator/core": "^0.10.2"
+    "@stylegator/app": "^0.10.3-rc.6",
+    "@stylegator/cli": "^0.10.3-rc.6",
+    "@stylegator/core": "^0.10.3-rc.6"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",


### PR DESCRIPTION

## Unreleased (2018-03-05)

#### :books: Dependencies
* `core`
  * [#143](https://github.com/farism/stylegator/pull/143) Update dependency resolve-url-loader to v2.3.0. ([@renovate[bot]](https://github.com/apps/renovate))
  * [#140](https://github.com/farism/stylegator/pull/140) Update dependency copy-webpack-plugin to v4.5.0. ([@renovate[bot]](https://github.com/apps/renovate))
  * [#139](https://github.com/farism/stylegator/pull/139) Update dependency html-webpack-plugin to v3.0.4. ([@renovate[bot]](https://github.com/apps/renovate))
  * [#134](https://github.com/farism/stylegator/pull/134) Update dependency html-webpack-plugin to v3. ([@renovate[bot]](https://github.com/apps/renovate))
* `app`, `cli`, `core`, `docs`
  * [#135](https://github.com/farism/stylegator/pull/135) Update dependency prettier to v1.11.1. ([@renovate[bot]](https://github.com/apps/renovate))
* `app`
  * [#133](https://github.com/farism/stylegator/pull/133) Update dependency react-live to v1.10.1. ([@renovate[bot]](https://github.com/apps/renovate))

#### Committers: 1
- Faris Mustafa ([farism](https://github.com/farism))
