### PR TITLE
Remove height 100 from app containers

### DIFF
--- a/packages/app/src/index.scss
+++ b/packages/app/src/index.scss
@@ -9,13 +9,11 @@
   body {
     color: #4d4d4d;
     font-family: Roboto;
-    height: 100%;
     min-height: 100%;
     overflow-x: hidden;
   }
 
   #app {
-    height: 100%;
     min-height: 100%;
   }
 


### PR DESCRIPTION
Removes `height: 100%` rule for `html, body, #app` and relies on `min-height` instead.