### PR TITLE
Prerelease (next) 0.13.1-rc.2

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.13.0",
+  "version": "0.13.1-rc.2",
   "npmClient": "yarn",
   "parallel": true,
   "message": "[ci skip] publish %s",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/app",
-  "version": "0.13.0",
+  "version": "0.13.1-rc.2",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/cli",
-  "version": "0.13.0",
+  "version": "0.13.1-rc.2",
   "description": "Stylegator CLI tool",
   "main": "lib/index.js",
   "repository": {
@@ -26,7 +26,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/core": "^0.13.0"
+    "@stylegator/core": "^0.13.1-rc.2"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/core",
-  "version": "0.13.0",
+  "version": "0.13.1-rc.2",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@stylegator/docs",
-  "version": "0.13.0",
+  "version": "0.13.1-rc.2",
   "description": "Stylegator main package",
   "main": "lib/index.js",
   "repository": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "prop-types-docs": "0.2.1",
-    "stylegator": "^0.13.0"
+    "stylegator": "^0.13.1-rc.2"
   },
   "devDependencies": {
     "husky": "0.14.3",

--- a/packages/stylegator/package.json
+++ b/packages/stylegator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylegator",
-  "version": "0.13.0",
+  "version": "0.13.1-rc.2",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {
@@ -26,9 +26,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/app": "^0.13.0",
-    "@stylegator/cli": "^0.13.0",
-    "@stylegator/core": "^0.13.0"
+    "@stylegator/app": "^0.13.1-rc.2",
+    "@stylegator/cli": "^0.13.1-rc.2",
+    "@stylegator/core": "^0.13.1-rc.2"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",


### PR DESCRIPTION

## Unreleased (2018-06-13)

#### :books: Dependencies
* `app`, `cli`, `core`, `docs`
  * [#250](https://github.com/farism/stylegator/pull/250) Update dependency prettier to v1.13.5. ([@renovate[bot]](https://github.com/apps/renovate))
* `app`
  * [#249](https://github.com/farism/stylegator/pull/249) Update dependency react-router-dom to v4.3.1. ([@renovate[bot]](https://github.com/apps/renovate))

#### Committers: 1
- Faris Mustafa ([farism](https://github.com/farism))
