### PR TITLE
Support defining react-live scope on sections

### DIFF
--- a/packages/app/src/partials/LiveMarkdown/LiveMarkdown.js
+++ b/packages/app/src/partials/LiveMarkdown/LiveMarkdown.js
@@ -24,12 +24,12 @@ class LiveMarkdown extends React.Component {
   }
 
   render() {
-    const { attributes } = this.props
+    const { attributes, scope } = this.props
     const { content, expanded } = this.state
 
     return (
       <div className={styles['live-markdown']}>
-        <LiveProvider code={content}>
+        <LiveProvider code={content} scope={scope}>
           {attributes.interactive === 'true' && (
             <div
               {...{
@@ -63,6 +63,7 @@ LiveMarkdown.propTypes = {
     interactive: PropTypes.string,
   }),
   content: PropTypes.string,
+  scope: PropTypes.object,
 }
 
 LiveMarkdown.defaultProps = {
@@ -70,6 +71,7 @@ LiveMarkdown.defaultProps = {
     interactive: 'true',
   },
   content: '',
+  scope: {},
 }
 
 export default LiveMarkdown

--- a/packages/app/src/partials/Page/Page.js
+++ b/packages/app/src/partials/Page/Page.js
@@ -5,7 +5,7 @@ import { getAttributes, getGlobalComponent, getPageSections } from '../../utils'
 import { LiveMarkdown, Props, StaticMarkdown } from '../'
 import styles from './page.scss'
 
-const getPageSection = (partials, section) => {
+const getPageSection = (partials, scope, section) => {
   const { StaticMarkdown, LiveMarkdown, Props } = partials
 
   let tag = section.match(/\{([a-zA-Z]*)\}/)
@@ -20,7 +20,7 @@ const getPageSection = (partials, section) => {
         const content = arr.length === 2 ? arr[1] : arr[0]
         const attrs = arr.length === 2 ? getAttributes(arr[0]) : undefined
 
-        return <LiveMarkdown {...{ content, attributes: attrs }} />
+        return <LiveMarkdown {...{ scope, content, attributes: attrs }} />
       case 'props':
         const attributes = getAttributes(contentWithoutTag)
         const props = getGlobalComponent(attributes.component).propInfo
@@ -38,7 +38,7 @@ const getPageSection = (partials, section) => {
   return <StaticMarkdown {...{ content: contentWithoutTag }} />
 }
 
-const Page = ({ content, title, partials }) => {
+const Page = ({ content, title, scope, partials }) => {
   const { PageHeader } = partials
 
   return (
@@ -46,7 +46,7 @@ const Page = ({ content, title, partials }) => {
       <PageHeader {...{ title }} />
       <div className={styles['page-content']}>
         {getPageSections(content).map((section, i) => (
-          <div key={i}>{getPageSection(partials, section)}</div>
+          <div key={i}>{getPageSection(partials, scope, section)}</div>
         ))}
       </div>
     </div>
@@ -61,10 +61,12 @@ Page.propTypes = {
     Props: PropTypes.func.isRequired,
     StaticMarkdown: PropTypes.func.isRequired,
   }).isRequired,
+  scope: PropTypes.object,
 }
 
 Page.defaultProps = {
   content: '',
+  scope: {},
 }
 
 export default Page

--- a/packages/app/src/utils/buildRoutes.js
+++ b/packages/app/src/utils/buildRoutes.js
@@ -3,12 +3,12 @@ import { Redirect, Route } from 'react-router-dom'
 
 import { pageLoader } from './'
 
-const buildRoute = ({ title, path, loader }) => (
+const buildRoute = ({ path, loader, ...section }) => (
   <Route
     {...{
-      key: title,
+      key: section.title,
       path,
-      component: loader(title),
+      component: loader(section),
     }}
   />
 )

--- a/packages/app/src/utils/pageLoader.js
+++ b/packages/app/src/utils/pageLoader.js
@@ -3,7 +3,7 @@ import * as R from 'ramda'
 
 import { getContext } from './'
 
-export default (loader, transform = R.identity) => title => {
+export default (loader, transform = R.identity) => ({ title, scope }) => {
   class PageLoader extends React.Component {
     constructor(props) {
       super(props)
@@ -21,7 +21,7 @@ export default (loader, transform = R.identity) => title => {
     render() {
       const { Page } = this.props.partials
 
-      return <Page {...{ title, content: this.state.content }} />
+      return <Page {...{ title, scope, content: this.state.content }} />
     }
   }
 

--- a/packages/docs/src/sections/authoring-content.md
+++ b/packages/docs/src/sections/authoring-content.md
@@ -28,7 +28,6 @@ ReactDOM.render(
 
 An interactive code sample can be created by using the `code` directive:
 
-
     ```code
     <button>a button</button>
     ```
@@ -42,7 +41,6 @@ This will create a sandbox for a viewer to play with:
 ## Non-interactive code samples
 
 A non-interactive code sample can be created by using the `code` directive with an `interactive: false` attribute:
-
 
     ```code
     interactive: false


### PR DESCRIPTION
`react-live` supports a `scope` prop, which is another way of doing globals. We currently have `components` but that could potentially cause clashes if you are using it with a monorepo and you have multiple packages that are using different versions of the same dependency.