### PR TITLE
Prerelease (next) 0.14.1-rc.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.14.0",
+  "version": "0.14.1-rc.1",
   "npmClient": "yarn",
   "parallel": true,
   "message": "[ci skip] publish %s",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/app",
-  "version": "0.14.0",
+  "version": "0.14.1-rc.1",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/cli",
-  "version": "0.14.0",
+  "version": "0.14.1-rc.1",
   "description": "Stylegator CLI tool",
   "main": "lib/index.js",
   "repository": {
@@ -26,7 +26,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/core": "^0.14.0"
+    "@stylegator/core": "^0.14.1-rc.1"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/core",
-  "version": "0.14.0",
+  "version": "0.14.1-rc.1",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@stylegator/docs",
-  "version": "0.14.0",
+  "version": "0.14.1-rc.1",
   "description": "Stylegator main package",
   "main": "lib/index.js",
   "repository": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "prop-types-docs": "0.2.1",
-    "stylegator": "^0.14.0"
+    "stylegator": "^0.14.1-rc.1"
   },
   "devDependencies": {
     "husky": "0.14.3",

--- a/packages/stylegator/package.json
+++ b/packages/stylegator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylegator",
-  "version": "0.14.0",
+  "version": "0.14.1-rc.1",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {
@@ -26,9 +26,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/app": "^0.14.0",
-    "@stylegator/cli": "^0.14.0",
-    "@stylegator/core": "^0.14.0"
+    "@stylegator/app": "^0.14.1-rc.1",
+    "@stylegator/cli": "^0.14.1-rc.1",
+    "@stylegator/core": "^0.14.1-rc.1"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",


### PR DESCRIPTION

## Unreleased (2018-08-01)

#### :books: Dependencies
* `app`, `cli`, `core`, `docs`
  * [#277](https://github.com/farism/stylegator/pull/277) Update dependency prettier to v1.14.0. ([@renovate[bot]](https://github.com/apps/renovate))

#### Committers: 1
- Faris Mustafa ([farism](https://github.com/farism))
