### PR TITLE
Prerelease (next) 0.16.1-rc.3

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.16.0",
+  "version": "0.16.1-rc.3",
   "npmClient": "yarn",
   "parallel": true,
   "message": "[ci skip] publish %s",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/app",
-  "version": "0.16.0",
+  "version": "0.16.1-rc.3",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/cli",
-  "version": "0.16.0",
+  "version": "0.16.1-rc.3",
   "description": "Stylegator CLI tool",
   "main": "lib/index.js",
   "repository": {
@@ -26,7 +26,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/core": "^0.16.0",
+    "@stylegator/core": "^0.16.1-rc.3",
     "find-up": "3.0.0",
     "yargs": "12.0.1"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/core",
-  "version": "0.16.0",
+  "version": "0.16.1-rc.3",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@stylegator/docs",
-  "version": "0.16.0",
+  "version": "0.16.1-rc.3",
   "description": "Stylegator main package",
   "main": "lib/index.js",
   "repository": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "prop-types-docs": "0.2.2",
-    "stylegator": "^0.16.0"
+    "stylegator": "^0.16.1-rc.3"
   },
   "devDependencies": {
     "husky": "0.14.3",

--- a/packages/stylegator/package.json
+++ b/packages/stylegator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylegator",
-  "version": "0.16.0",
+  "version": "0.16.1-rc.3",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {
@@ -26,9 +26,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/app": "^0.16.0",
-    "@stylegator/cli": "^0.16.0",
-    "@stylegator/core": "^0.16.0"
+    "@stylegator/app": "^0.16.1-rc.3",
+    "@stylegator/cli": "^0.16.1-rc.3",
+    "@stylegator/core": "^0.16.1-rc.3"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",


### PR DESCRIPTION

## Unreleased (2018-08-31)

#### :books: Dependencies
* `app`
  * [#328](https://github.com/farism/stylegator/pull/328) Update dependency recompose to v0.30.0. ([@renovate[bot]](https://github.com/apps/renovate))
* Other
  * [#327](https://github.com/farism/stylegator/pull/327) Update dependency execa-pro to v1.0.8. ([@renovate[bot]](https://github.com/apps/renovate))
* `docs`
  * [#326](https://github.com/farism/stylegator/pull/326) Update dependency prop-types-docs to v0.2.2. ([@renovate[bot]](https://github.com/apps/renovate))

#### Committers: 1
- Faris Mustafa ([farism](https://github.com/farism))
