### PR TITLE
Prerelease (next) 0.17.3-rc.5

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.17.2",
+  "version": "0.17.3-rc.5",
   "npmClient": "yarn",
   "parallel": true,
   "message": "[ci skip] publish %s",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/app",
-  "version": "0.17.2",
+  "version": "0.17.3-rc.5",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/cli",
-  "version": "0.17.2",
+  "version": "0.17.3-rc.5",
   "description": "Stylegator CLI tool",
   "main": "lib/index.js",
   "repository": {
@@ -26,7 +26,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/core": "^0.17.2",
+    "@stylegator/core": "^0.17.3-rc.5",
     "find-up": "3.0.0",
     "yargs": "12.0.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/core",
-  "version": "0.17.2",
+  "version": "0.17.3-rc.5",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@stylegator/docs",
-  "version": "0.17.2",
+  "version": "0.17.3-rc.5",
   "description": "Stylegator main package",
   "main": "lib/index.js",
   "repository": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "prop-types-docs": "0.2.2",
-    "stylegator": "^0.17.2"
+    "stylegator": "^0.17.3-rc.5"
   },
   "devDependencies": {
     "husky": "0.14.3",

--- a/packages/stylegator/package.json
+++ b/packages/stylegator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylegator",
-  "version": "0.17.2",
+  "version": "0.17.3-rc.5",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {
@@ -26,9 +26,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/app": "^0.17.2",
-    "@stylegator/cli": "^0.17.2",
-    "@stylegator/core": "^0.17.2"
+    "@stylegator/app": "^0.17.3-rc.5",
+    "@stylegator/cli": "^0.17.3-rc.5",
+    "@stylegator/core": "^0.17.3-rc.5"
   },
   "devDependencies": {
     "@babel/cli": "7.1.0",


### PR DESCRIPTION

## Unreleased (2018-09-20)

#### :books: Dependencies
* `core`
  * [#373](https://github.com/farism/stylegator/pull/373) Update dependency webpack-sources to v1.3.0. ([@renovate[bot]](https://github.com/apps/renovate))
  * [#366](https://github.com/farism/stylegator/pull/366) Update dependency resolve-url-loader to v3. ([@renovate[bot]](https://github.com/apps/renovate))
  * [#364](https://github.com/farism/stylegator/pull/364) Update dependency webpack to v4.19.1. ([@renovate[bot]](https://github.com/apps/renovate))
* `app`, `cli`, `core`, `docs`
  * [#371](https://github.com/farism/stylegator/pull/371) Update dependency prettier to v1.14.3. ([@renovate[bot]](https://github.com/apps/renovate))
* `app`, `cli`, `core`, `stylegator`
  * [#367](https://github.com/farism/stylegator/pull/367) Update babel monorepo to v7.1.0. ([@renovate[bot]](https://github.com/apps/renovate))

#### Committers: 1
- Faris Mustafa ([farism](https://github.com/farism))
