### PR TITLE
Prerelease (next) 0.19.1-rc.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,35 @@
 
+## v0.18.0 (2018-10-02)
+
+#### :books: Dependencies
+* `core`
+  * [#377](https://github.com/farism/stylegator/pull/377) Update dependency webpack to v4.20.2. ([@renovate[bot]](https://github.com/apps/renovate))
+  * [#380](https://github.com/farism/stylegator/pull/380) Update dependency babel-loader to v8.0.4. ([@renovate[bot]](https://github.com/apps/renovate))
+  * [#376](https://github.com/farism/stylegator/pull/376) Update dependency webpack-dev-server to v3.1.9. ([@renovate[bot]](https://github.com/apps/renovate))
+  * [#373](https://github.com/farism/stylegator/pull/373) Update dependency webpack-sources to v1.3.0. ([@renovate[bot]](https://github.com/apps/renovate))
+  * [#366](https://github.com/farism/stylegator/pull/366) Update dependency resolve-url-loader to v3. ([@renovate[bot]](https://github.com/apps/renovate))
+  * [#364](https://github.com/farism/stylegator/pull/364) Update dependency webpack to v4.19.1. ([@renovate[bot]](https://github.com/apps/renovate))
+* `app`, `cli`, `core`, `docs`
+  * [#378](https://github.com/farism/stylegator/pull/378) Update dependency husky to v1. ([@renovate[bot]](https://github.com/apps/renovate))
+  * [#372](https://github.com/farism/stylegator/pull/372) Update dependency lint-staged to v7.3.0. ([@renovate[bot]](https://github.com/apps/renovate))
+  * [#371](https://github.com/farism/stylegator/pull/371) Update dependency prettier to v1.14.3. ([@renovate[bot]](https://github.com/apps/renovate))
+* `app`, `cli`, `core`, `stylegator`
+  * [#382](https://github.com/farism/stylegator/pull/382) Update babel monorepo to v7.1.2. ([@renovate[bot]](https://github.com/apps/renovate))
+  * [#367](https://github.com/farism/stylegator/pull/367) Update babel monorepo to v7.1.0. ([@renovate[bot]](https://github.com/apps/renovate))
+* `app`
+  * [#379](https://github.com/farism/stylegator/pull/379) Update dependency marked to v0.5.1. ([@renovate[bot]](https://github.com/apps/renovate))
+  * [#365](https://github.com/farism/stylegator/pull/365) Update react monorepo to v16.5.2. ([@renovate[bot]](https://github.com/apps/renovate))
+* `docs`
+  * [#381](https://github.com/farism/stylegator/pull/381) Update dependency prop-types-docs to v0.3.0. ([@renovate[bot]](https://github.com/apps/renovate))
+
+#### :nail_care: Enhancement
+* `app`, `docs`
+  * [#392](https://github.com/farism/stylegator/pull/392) Refactor props table. ([@farism](https://github.com/farism))
+
+#### Committers: 1
+- Faris Mustafa ([farism](https://github.com/farism))
+
+
 ## v0.17.2 (2018-09-13)
 
 #### :bug: Bug Fix

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.7.1",
-  "version": "0.19.0",
+  "version": "0.19.1-rc.0",
   "npmClient": "yarn",
   "parallel": true,
   "message": "[ci skip] publish %s",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/app",
-  "version": "0.19.0",
+  "version": "0.19.1-rc.0",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/cli",
-  "version": "0.19.0",
+  "version": "0.19.1-rc.0",
   "description": "Stylegator CLI tool",
   "main": "lib/index.js",
   "repository": {
@@ -26,7 +26,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/core": "^0.19.0",
+    "@stylegator/core": "^0.19.1-rc.0",
     "find-up": "3.0.0",
     "yargs": "12.0.2"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stylegator/core",
-  "version": "0.19.0",
+  "version": "0.19.1-rc.0",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@stylegator/docs",
-  "version": "0.19.0",
+  "version": "0.19.1-rc.0",
   "description": "Stylegator main package",
   "main": "lib/index.js",
   "repository": {
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "prop-types-docs": "0.3.0",
-    "stylegator": "^0.19.0"
+    "stylegator": "^0.19.1-rc.0"
   },
   "devDependencies": {
     "husky": "3.0.8",

--- a/packages/stylegator/package.json
+++ b/packages/stylegator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylegator",
-  "version": "0.19.0",
+  "version": "0.19.1-rc.0",
   "description": "styleguide static generator for html and js",
   "main": "lib/index.js",
   "repository": {
@@ -26,9 +26,9 @@
     "test": "jest"
   },
   "dependencies": {
-    "@stylegator/app": "^0.19.0",
-    "@stylegator/cli": "^0.19.0",
-    "@stylegator/core": "^0.19.0"
+    "@stylegator/app": "^0.19.1-rc.0",
+    "@stylegator/cli": "^0.19.1-rc.0",
+    "@stylegator/core": "^0.19.1-rc.0"
   },
   "devDependencies": {
     "@babel/cli": "7.1.2",


### PR DESCRIPTION

## Unreleased (2019-10-24)

#### :books: Dependencies
* `app`, `cli`, `core`, `docs`
  * [#566](https://github.com/farism/stylegator/pull/566) Update dependency husky to v3. ([@renovate[bot]](https://github.com/apps/renovate))
* `app`, `cli`, `core`, `docs`, `stylegator`
  * [#569](https://github.com/farism/stylegator/pull/569) Update dependency rimraf to v2.7.1. ([@renovate[bot]](https://github.com/apps/renovate))

#### Committers: 0


