### PR TITLE
fix: don't catch error to handle ie11 bugs

### DIFF
--- a/packages/app/src/partials/LiveMarkdown/LiveMarkdown.js
+++ b/packages/app/src/partials/LiveMarkdown/LiveMarkdown.js
@@ -4,8 +4,6 @@ import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live'
 
 import styles from './liveMarkdown.scss'
 
-const fixStyleProps = content => content.replace(/style(?!=\{)/g, 'style={{}}')
-
 class LiveMarkdown extends React.Component {
   constructor(props) {
     super(props)
@@ -13,23 +11,26 @@ class LiveMarkdown extends React.Component {
     this.state = {
       expanded: false,
       content: props.content,
-      contentEditing: props.content,
     }
-  }
-
-  componentDidCatch(error, info) {
-    this.setState({
-      content: fixStyleProps(this.state.contentEditing),
-    })
   }
 
   render() {
     const { attributes, scope } = this.props
+
     const { content, expanded } = this.state
 
     return (
       <div className={styles['live-markdown']}>
         <LiveProvider code={content} scope={scope}>
+          <div className={styles['live-markdown-preview']}>
+            <LivePreview />
+          </div>
+          {expanded && (
+            <div className={styles['live-markdown-editor']}>
+              <LiveEditor />
+            </div>
+          )}
+          <LiveError />
           {attributes.interactive === 'true' && (
             <div
               {...{
@@ -41,17 +42,6 @@ class LiveMarkdown extends React.Component {
               {expanded ? '</>' : '< >'}
             </div>
           )}
-          <div className={styles['live-markdown-preview']}>
-            <LivePreview />
-          </div>
-          {expanded && (
-            <div className={styles['live-markdown-editor']}>
-              <LiveEditor
-                onChange={contentEditing => this.setState({ contentEditing })}
-              />
-            </div>
-          )}
-          <LiveError />
         </LiveProvider>
       </div>
     )


### PR DESCRIPTION
affects: @stylegator/app

- IE11 had a bug with trying to use `style={{}}` with an older version of `react-live`
- Due to that, I had put some logic in to catch errors and correct the issue
- WIth the latest version of react-live this seems to not be triggering, so just take it out, and hopefully IE11 is fixed (if not, oh well)